### PR TITLE
feat(index): add gitops index for git operations data in GitHub

### DIFF
--- a/packages/all/common/addonfactory_indexes/default/indexes.conf
+++ b/packages/all/common/addonfactory_indexes/default/indexes.conf
@@ -139,6 +139,11 @@ homePath   = $SPLUNK_DB/print/db
 coldPath   = $SPLUNK_DB/print/colddb
 thawedPath = $SPLUNK_DB/print/thaweddb
 
+[gitops]
+homePath   = $SPLUNK_DB/gitops/db
+coldPath   = $SPLUNK_DB/gitops/colddb
+thawedPath = $SPLUNK_DB/gitops/thaweddb
+
 [lastchance]
 homePath   = $SPLUNK_DB/lastchance/db
 coldPath   = $SPLUNK_DB/lastchance/colddb


### PR DESCRIPTION
Added entry for new index **gitops** for git operations data of Github TA as discussed in the Slack thread : https://splunk.slack.com/archives/GSZDDN1GF/p1637121222230800?thread_ts=1636983518.203900&cid=GSZDDN1GF

